### PR TITLE
fix: footer unified setting link color

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -216,6 +216,7 @@ const updateNavigationStyle = (
   button[data-testid="awsc-footer-language-selector-button"],
   a[data-testid="awsc-footer-privacy-policy"],
   a[data-testid="awsc-footer-terms-of-use"],
+  span[data-testid="awsc-footer-unified-settings-language-link"],
   button[data-testid="awsc-footer-cookie-preferences"],
   span[data-testid="awsc-footer-copyright"] {
     color: ${foregroundColor} !important;


### PR DESCRIPTION
## Summary

fix footer unified link color

### Before

<img width="573" alt="image" src="https://user-images.githubusercontent.com/13391129/170704815-9a21c2fa-c80e-4856-888b-92b2e9c22a36.png">

### After

<img width="598" alt="image" src="https://user-images.githubusercontent.com/13391129/170704725-e2c71984-c0a8-49c4-8aeb-7f6ffa7ebc60.png">

