### PR TITLE
Support for AWS display method specification changes

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,9 +9,7 @@
   "permissions": ["storage"],
   "content_scripts": [
     {
-      "js": [
-        "content.js"
-      ],
+      "js": ["content.js"],
       "matches": [
         "https://*.console.aws.amazon.com/*",
         "https://phd.aws.amazon.com/*",
@@ -21,12 +19,8 @@
       "run_at": "document_end"
     },
     {
-      "js": [
-        "scraping.js"
-      ],
-      "matches": [
-        "https://*.awsapps.com/start*"
-      ],
+      "js": ["scraping.js"],
+      "matches": ["https://*.awsapps.com/start*"],
       "run_at": "document_end"
     }
   ],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "AWS Peacock Management Console",
   "description": "Browser Extension to change color of AWS Management Console, by Account ID",
   "version": "2.5",
@@ -9,17 +9,25 @@
   "permissions": ["storage"],
   "content_scripts": [
     {
-      "js": ["content.js"],
+      "js": [
+        "content.js"
+      ],
       "matches": [
         "https://*.console.aws.amazon.com/*",
         "https://phd.aws.amazon.com/*",
         "https://*.console.amazonaws-us-gov.com/*",
         "https://*.console.amazonaws.cn/*"
-      ]
+      ],
+      "run_at": "document_end"
     },
     {
-      "js": ["scraping.js"],
-      "matches": ["https://*.awsapps.com/start*"]
+      "js": [
+        "scraping.js"
+      ],
+      "matches": [
+        "https://*.awsapps.com/start*"
+      ],
+      "run_at": "document_end"
     }
   ],
   "options_ui": {

--- a/src/content.ts
+++ b/src/content.ts
@@ -301,4 +301,13 @@ const run = async () => {
     }
   }
 }
-run()
+
+function waitForElementToDisplay(selector: string, time: number) {
+  var interval = setInterval(function () {
+    if (document.querySelector(selector) !== null) {
+      clearInterval(interval);
+      run();
+    }
+  }, time);
+}
+waitForElementToDisplay("#nav-usernameMenu", 100);


### PR DESCRIPTION
When obtaining AccountID, the corresponding element did not exist and was Undefined, so the system now waits until the AccountID element is displayed.

Any other better implementation would be appreciated.
Also changed to manifestnoV3.