### PR TITLE
アカウントIDエリアのロードタイミングが変更され、アカウントID取得が行えなくなった課題の修正

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "AWS Peacock Management Console",
   "description": "Browser Extension to change color of AWS Management Console, by Account ID",
-  "version": "2.6",
+  "version": "2.7",
   "icons": {
     "128": "icons/128.png"
   },

--- a/src/content.ts
+++ b/src/content.ts
@@ -310,4 +310,4 @@ function waitForElementToDisplay(selector: string, time: number) {
     }
   }, time);
 }
-waitForElementToDisplay("#nav-usernameMenu", 100);
+waitForElementToDisplay("button[data-testid=\"awsc-copy-accountid\"]", 100);


### PR DESCRIPTION
特定要素が表示表示されるまで待機するという処理で、
表示の判定に使用しているセレクターをbutton[data-testid=\"awsc-copy-accountid\"]に変更しました。

マニュフェストversionを2.7に変更しました