### PR TITLE
fix: get account id from even switch role

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -55,18 +55,18 @@ const getOriginalAccountMenuButtonBackground = () => {
 
 const getAccountIdFromDescendantByDataTestidEqualsAwscCopyAccountId = (accountDetailMenu: HTMLElement): string | null => {
   const copyAccountIdButton = accountDetailMenu.querySelector<HTMLElement>('button[data-testid="awsc-copy-accountid"]')
-  return (copyAccountIdButton?.previousElementSibling as HTMLSpanElement)?.innerText?.replace(/\-/g, '')
+  return (copyAccountIdButton?.previousElementSibling as HTMLSpanElement)?.innerText?.replace(/-/g, '')
 }
 
 const getAccountIdByRegex = (accountDetailMenu: HTMLElement) => {
   let accountId = null;
-  let regex = /^\d{4}-\d{4}-\d{4}$/; // Regular expression to match the pattern ****-****-****
-  let spans = accountDetailMenu.querySelectorAll('span');
+  const regex = /^\d{4}-\d{4}-\d{4}$/; // Regular expression to match the pattern ****-****-****
+  const spans = accountDetailMenu.querySelectorAll('span');
 
   spans.forEach(span => {
     const spanText = span.textContent ? span.textContent.trim() : '';
     if (regex.test(spanText)) {
-        accountId = spanText;
+        accountId = spanText.replace(/-/g, '');
     }
   });
 
@@ -75,7 +75,7 @@ const getAccountIdByRegex = (accountDetailMenu: HTMLElement) => {
 
 const getAccountId = async (): Promise<string | null | undefined> => {
   try {
-    const accountDetailMenu = await waitForElement('button[data-testid="account-detail-menu"]', 10000)
+    const accountDetailMenu = await waitForElement('div[data-testid="account-detail-menu"]', 10000)
     return getAccountIdFromDescendantByDataTestidEqualsAwscCopyAccountId(accountDetailMenu) || getAccountIdByRegex(accountDetailMenu);
   } catch (e) {
     console.error(e)

--- a/src/content.ts
+++ b/src/content.ts
@@ -53,10 +53,30 @@ const getOriginalAccountMenuButtonBackground = () => {
   return selectElement('span[data-testid="account-menu-button__background"]')
 }
 
+const getAccountIdFromDescendantByDataTestidEqualsAwscCopyAccountId = (accountDetailMenu: HTMLElement): string | null => {
+  const copyAccountIdButton = accountDetailMenu.querySelector<HTMLElement>('button[data-testid="awsc-copy-accountid"]')
+  return (copyAccountIdButton?.previousElementSibling as HTMLSpanElement)?.innerText?.replace(/\-/g, '')
+}
+
+const getAccountIdByRegex = (accountDetailMenu: HTMLElement) => {
+  let accountId = null;
+  let regex = /^\d{4}-\d{4}-\d{4}$/; // Regular expression to match the pattern ****-****-****
+  let spans = accountDetailMenu.querySelectorAll('span');
+
+  spans.forEach(span => {
+    const spanText = span.textContent ? span.textContent.trim() : '';
+    if (regex.test(spanText)) {
+        accountId = spanText;
+    }
+  });
+
+  return accountId;
+}
+
 const getAccountId = async (): Promise<string | null | undefined> => {
   try {
-    const copyAccountIdButton = await waitForElement('button[data-testid="awsc-copy-accountid"]', 10000)
-    return (copyAccountIdButton?.previousElementSibling as HTMLSpanElement)?.innerText?.replace(/\-/g, '')
+    const accountDetailMenu = await waitForElement('button[data-testid="account-detail-menu"]', 10000)
+    return getAccountIdFromDescendantByDataTestidEqualsAwscCopyAccountId(accountDetailMenu) || getAccountIdByRegex(accountDetailMenu);
   } catch (e) {
     console.error(e)
     return null


### PR DESCRIPTION
# Summary

get account id even if switch role

## Motivation

https://github.com/xhiroga/aws-peacock-management-console/issues/67

## Evidences

Note: These debug messages will be removed from producntion build.

### By not roles
![image](https://github.com/xhiroga/aws-peacock-management-console/assets/13391129/184f659e-bb54-44b3-a062-b10dcb63576d)

### By roles
![image](https://github.com/xhiroga/aws-peacock-management-console/assets/13391129/80257ae1-8e3c-4906-8836-2f99c09b97d6)

