### PR TITLE
Optionally match on username

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -74,6 +74,10 @@ const getRegion = () => {
   return document.getElementById('awsc-mezz-region')?.getAttribute('content')
 }
 
+const getUsername = () => {
+  return document.getElementById('nav-usernameMenu')?.getAttribute('aria-label')
+}
+
 const loadConfigList = async (): Promise<ConfigList | null> => {
   const configList = await configRepository.get()
   if (configList) {
@@ -91,19 +95,20 @@ const parseConfigList = (configList: string) => {
   }
 }
 
-const isEnvMatch = (env: Environment, accountId: string, region: string) =>
-  String(env.account) === accountId && (env.region ? env.region === region : true)
+const isEnvMatch = (env: Environment, accountId: string, region: string, username: string) =>
+  String(env.account) === accountId && (env.region ? env.region === region : true) && (env.username ? env.username == username : true)
 
 const findConfig = (
   configList: ConfigList,
   accountId: string,
-  region: string
+  region: string,
+  username: string
 ): Config | undefined =>
   configList.find((config: Config) => {
     if (Array.isArray(config.env)) {
-      return config.env.some((e) => isEnvMatch(e, accountId, region))
+      return config.env.some((e) => isEnvMatch(e, accountId, region, username))
     } else {
-      return isEnvMatch(config.env, accountId, region)
+      return isEnvMatch(config.env, accountId, region, username)
     }
   })
 
@@ -283,8 +288,9 @@ const run = async () => {
   const configList = await loadConfigList()
   const accountId = await getAccountId()
   const region = getRegion()
-  if (configList && accountId && region) {
-    const config = findConfig(configList, accountId, region)
+  const username = getUsername()
+  if (configList && accountId && region && username) {
+    const config = findConfig(configList, accountId, region, username)
     if (config?.style) {
       updateStyle(config?.style)
     }

--- a/src/lib/config-repository.ts
+++ b/src/lib/config-repository.ts
@@ -3,6 +3,7 @@ import { Repository, RepositoryProps } from './repository'
 export type Environment = {
   account: string
   region?: string
+  username?: string
 }
 export type Config = {
   env: Environment | Environment[]


### PR DESCRIPTION
# Summary

Matches on username optional like region

## Motivation

When accessing environments we have various roles that show up in the form of the username with SSO - this allows for changing the color based on the username/role - so edit contexts can be a different color than just read contexts
