### PR TITLE
fix: update AWS logo color selector to apply to all paths

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -142,7 +142,7 @@ const insertStyleTag = (css: string) => {
 
 const updateAwsLogo = (color: string) => {
   const css = `
-  a[data-testid="nav-logo"] > svg > path:first-of-type{
+  a[data-testid="nav-logo"] > svg > path{
     fill: ${color} !important;
   }`
   insertStyleTag(css)


### PR DESCRIPTION
# Summary

## Before
<img width="302" alt="image" src="https://github.com/user-attachments/assets/b80bc8c2-0c14-4488-8ffd-1dfb34c288ce" />

## After

<img width="294" alt="image" src="https://github.com/user-attachments/assets/ef1bb03d-429a-45d1-9c4f-e5a24a89515d" />
