### PR TITLE
fix: do not use area-label

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -216,7 +216,7 @@ const updateNavigationStyle = (
   // 4. Conversely, within Atoms, use the Descendent Selector to avoid the effects of AWS refactoring.
   // 5. Instead of specifying `path`, `g`, `circle` individually, use `svg > *`.
   const css = `
-  header[data-testid="awsc-nav-header"] nav[aria-label="Global"] {
+  header[data-testid="awsc-nav-header"] > nav {
     background-color: ${navigationBackgroundColor} !important;
   }
   button[data-testid="aws-services-list-button"],


### PR DESCRIPTION
# Summary

Instead of use area-label, see child element

## Motivation

#102 

## Before

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/142b5763-5ca8-4e25-98a5-4722682cfcf5" />

## After

<img width="1682" alt="image" src="https://github.com/user-attachments/assets/f4e41c15-c696-4a1a-baf2-66d70a1ef9c8" />

