### PR TITLE
docs: DO NOT USE `area-label`as a selector

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -215,6 +215,7 @@ const updateNavigationStyle = (
   // 3. Use the `data-testid` of the closest parent element of the element you want to change the color of.
   // 4. Conversely, within Atoms, use the Descendent Selector to avoid the effects of AWS refactoring.
   // 5. Instead of specifying `path`, `g`, `circle` individually, use `svg > *`.
+  // 6. DO NOT USE `area-label`as a selector. Its value is NOT stable and may change depending on the user's language settings.
   const css = `
   header[data-testid="awsc-nav-header"] > nav {
     background-color: ${navigationBackgroundColor} !important;


### PR DESCRIPTION
# Summary

If I write it in a comment, GitHub Copilot will warn us in the near future, even if we forget or someone who doesn't know what's going on contributes it.

## Motivation

https://github.com/xhiroga/aws-peacock-management-console/issues/102#issuecomment-2614263529
