### PR TITLE
Fix/ The AWS account name is not displayed

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -57,7 +57,7 @@ export const patchAccountName = (accountName: Account, multiSessionSupportEnable
     }
   } else {
     const userName = accountMenuButton?.getAttribute('aria-label')
-    const targetSpan = accountMenuButton?.querySelector<HTMLSpanElement>('*[class*="_more-menu__button"] span')
+    const targetSpan = accountMenuButton?.querySelector<HTMLSpanElement>('[data-testid="awsc-nav-account-menu-button"] span:nth-child(2)')
     const title = accountMenuButton?.getAttribute('title')
     if (userName && targetSpan && title && isNotIamUserButAwsSsoUser(title)) {
       targetSpan.innerText = `${userName} @ ${accountName.accountName}`


### PR DESCRIPTION
# Summary
The AWS account name is not displayed (Issue: https://github.com/xhiroga/aws-peacock-management-console/issues/115)

## Motivation
I want to display aws account name in aws console when I log in via identitycenter again

## Unit Test

- [ ] `yarn test` passes
One test is failing because I've changed the element retrieval logic itself. 
If it's okay to modify the test content, I'll update it and submit another pull request.
```
 FAIL  src/lib/util.test.ts
  ✓ updateAccounts works (2 ms)
  ✓ toAccountNameAndId works (15 ms)
  ✕ patchAccountNameIfAwsSso works: AWS SSO, Account Name (5 ms)

  ● patchAccountNameIfAwsSso works: AWS SSO, Account Name

    expect(received).toEqual(expected) // deep equality

    Expected: "AWSReadOnlyAccess/hiroga @ Dev"
    Received: undefined

      70 |   const actual = document.querySelector<HTMLSpanElement>('span[title]')?.innerText
      71 |
    > 72 |   expect(actual).toEqual(expected);
         |                  ^
      73 | })
      74 |

      at Object.<anonymous> (src/lib/util.test.ts:72:18)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 2 passed, 3 total
Snapshots:   0 total
Time:        1.72 s
Ran all test suites.
error Command failed with exit code 1.
```


## Manual Test

- [x] Works correctly with Multi-session enabled, SSO user, English
  - [x] navigationBackgroundColor is applied
    - [x] Background color ◣ is displayed at the bottom left of the favicon
  - [ ] accountMenuButtonBackgroundColor is applied
  - [x] accountName is displayed as `accountName (accountId)`
  - [x] No errors are displayed in the console
- [ ] Works correctly with Multi-session enabled, IAM user, English
- [ ] Works correctly with Multi-session enabled, switched role from IAM user, English
- [ ] Works correctly with Multi-session enabled, root user, English
- [x] Works correctly with Multi-session disabled, SSO user, English
  - [x] accountName is displayed as `userName @ accountName`
- [x] Works correctly with Multi-session disabled, IAM user, English
- [x] Works correctly with Multi-session disabled, switched role from IAM user, English
- [x] Works correctly with Multi-session disabled, root user, English
- [x] Works correctly with Japanese (= non-English) language
- [x] Options settings screen works correctly when modified
  - [x] Error messages are displayed for incorrect account ID, regex, and color code
  - [x] Can be saved when there are no errors
- [x] Works correctly on both Chrome and Firefox when file names or manifest.json are modified

Regarding the background color of the menu button during multi-session, it seems the background color wasn't changing even before my code modifications. Should it be changing?
aws-peacock-management-console v2.17


I targeted the <span> element with a class name containing _more-menu__button because the full class name within the button element seemed likely to change. Please let me know if there's a better approach.