### PR TITLE
fix: Keep IAM Role name visible when using switch role

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -245,6 +245,9 @@ const updateNavigationStyle = (
   {
     color: ${foregroundColor} !important;
   }
+  div[data-testid="awsc-account-info-tile"] div[data-testid] span {
+    background: transparent !important;
+  }
   @media only screen and (min-width: 620px) {
     ${accountMenuButtonBackgroundColorEnabled ||
       getOriginalAccountMenuButtonBackground()


### PR DESCRIPTION
# Summary

Hi😀Thanks for the useful extension!

This pull request fixes a CSS issue where the role name becomes blacked-out when using **Switch Role**.  

(*) And this pull request is meant to be used together with AWS official account color feature. 
https://aws.amazon.com/about-aws/whats-new/2025/08/aws-management-console-assigning-color-aws-account/

👇️IAM User
<img width="1920" height="130" alt="image" src="https://github.com/user-attachments/assets/58e2a046-3dec-4d68-a07b-043302816504" />

👇️Switch Role
<img width="1920" height="129" alt="image" src="https://github.com/user-attachments/assets/b264ade3-98b7-45bd-ada6-112782bf157b" />

👇️IAM Identity Center (SSO)
<img width="1920" height="127" alt="image" src="https://github.com/user-attachments/assets/8ed5c322-3df4-436a-8430-fa9d5266cd7f" />

## Motivation

To fix it👍 

## Unit Test

- [x] `yarn test` passes

```sh
$ yarn test
yarn run v1.22.22
warning ../../../../package.json: No license field
$ jest
 PASS  src/lib/util.test.ts
  ✓ updateAccounts works (1 ms)
  ✓ toAccountNameAndId works (10 ms)
  ✓ patchAccountNameIfAwsSso works: AWS SSO, Account Name (3 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.111 s
Ran all test suites.
✨  Done in 2.02s.
```

## Manual Test

I could not confirm all possible test cases.
Your support in testing would be very helpful🙏 

- [x] Works correctly with Multi-session enabled, SSO user, English
  - [x] navigationBackgroundColor is applied
    - [x] Background color ◣ is displayed at the bottom left of the favicon
  - [ ] accountMenuButtonBackgroundColor is applied
  - [ ] accountName is displayed as `accountName (accountId)`
  - [x] No errors are displayed in the console
- [x] Works correctly with Multi-session enabled, IAM user, English
- [ ] Works correctly with Multi-session enabled, switched role from IAM user, English
- [x] Works correctly with Multi-session enabled, root user, English
- [x] Works correctly with Multi-session disabled, SSO user, English
  - [x] accountName is displayed as `userName @ accountName`
- [x] Works correctly with Multi-session disabled, IAM user, English
- [x] Works correctly with Multi-session disabled, switched role from IAM user, English
- [ ] Works correctly with Multi-session disabled, root user, English
- [x] Works correctly with Japanese (= non-English) language
- [x] Options settings screen works correctly when modified
  - [x] Error messages are displayed for incorrect account ID, regex, and color code
  - [x] Can be saved when there are no errors
- [ ] Works correctly on both Chrome and Firefox when file names or manifest.json are modified

👇️Switch Role
<img width="1920" height="126" alt="image" src="https://github.com/user-attachments/assets/32b1a1f2-f011-4743-8b55-fe86bd4d8a90" />

---

If my implementation is not correct, please feel free to give feedback or close this pull request.

Thank you so much!!!